### PR TITLE
Update werkzeug version constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     folder: github
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - moto_server = moto.server:main
@@ -31,7 +31,7 @@ requirements:
     - cryptography >=3.3.1
     - requests >=2.5
     - xmltodict
-    - werkzeug <2.2.0,>=0.5
+    - werkzeug >=0.5,!=2.2.0,!=2.2.1
     - pyyaml >=5.1
     - pytz
     - python-dateutil >=2.1,<3.0.0


### PR DESCRIPTION
Moto is [now compatible](https://github.com/getmoto/moto/blob/master/CHANGELOG.md#408) with werkzeug 2.2.2+.
Copied the new constraints from [moto's setup.cfg](https://github.com/getmoto/moto/blob/master/setup.cfg).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.